### PR TITLE
Updating my own author URL

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -5,7 +5,7 @@
 	"author": [
 		"[http://meta.brickimedia.org/wiki/User:Codyn329 Codyn329]",
 		"[http://meta.brickimedia.org/wiki/User:MtMNC MtMNC]",
-		"[http://meta.brickimedia.org/wiki/User:ToaMeiko George Barnick]",
+		"[//www.mediawiki.org/wiki/User:GeorgeBarnick George Barnick]",
 		"[http://meta.brickimedia.org/wiki/User:Jack_Phoenix Jack Phoenix]"
 	],
 	"url": "https://www.mediawiki.org/wiki/Skin:Material",


### PR DESCRIPTION
I prefer my MediaWiki.org user page for anything pertaining to MediaWiki development. If a viewer is interested, they can find my Brickimedia user page through my MediaWiki.org user page.